### PR TITLE
feat(auth): add "Remember Me" option to login functionality

### DIFF
--- a/X.md
+++ b/X.md
@@ -1,8 +1,0 @@
-``mysql
-sudo mysql
-
-ALTER USER 'root'@'localhost' IDENTIFIED BY 'devpass';
-FLUSH PRIVILEGES;
-EXIT;
-
-``

--- a/routing/authRouter.js
+++ b/routing/authRouter.js
@@ -86,9 +86,10 @@ router.post("/register", async (req, res) => {
  * @param {Object} req.body - Login-Daten
  * @param {string} req.body.email - E-Mail-Adresse
  * @param {string} req.body.password - Passwort
+ * @param {boolean} [req.body.remember] - "Remember Me" Option für persistenten Login
  */
 router.post("/login", async (req, res) => {
-  const { email, password } = req.body;
+  const { email, password, remember = false } = req.body;
   const validation = validateLoginInput(email, password);
 
   if (!validation.valid) {
@@ -117,6 +118,7 @@ router.post("/login", async (req, res) => {
 
     return sendSuccess(res, "Login erfolgreich. Willkommen zurück!", {
       userId: result.user.id,
+      remember: remember,
     });
   } catch (err) {
     return sendServerError(res, "Login-Fehler");


### PR DESCRIPTION
This pull request introduces a small enhancement to the authentication logic and removes some outdated documentation. The most important change is the addition of support for a "Remember Me" option during user login, which allows for persistent sessions.

Authentication feature update:
* Added an optional `remember` field to the login endpoint in `authRouter.js`, allowing users to request a persistent login session. The value is included in the API response for further handling.

Documentation cleanup:
* Removed obsolete MySQL credential reset instructions from `X.md`.