### PR TITLE
fix: remove unnecessary CORS origins from configuration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -83,9 +83,7 @@ const CONFIG = {
     CORS_ORIGINS: [
       "http://localhost:3000",
       "http://localhost:5500",
-      "http://localhost:5501",
       "http://127.0.0.1:5500",
-      "http://127.0.0.1:5501",
       "http://localhost:8080",
       "http://localhost:8000",
     ],


### PR DESCRIPTION
This pull request makes a small update to the CORS configuration by removing two local origins from the allowed list. This helps tighten development environment security and reduces unnecessary exposure.

* Removed `http://localhost:5501` and `http://127.0.0.1:5501` from the `CORS_ORIGINS` array in `config/environment.js`.